### PR TITLE
dotty: 0.14.0-RC1 -> 0.18.1

### DIFF
--- a/pkgs/development/compilers/scala/dotty-bare.nix
+++ b/pkgs/development/compilers/scala/dotty-bare.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, makeWrapper, jre, ncurses }:
 
 stdenv.mkDerivation rec {
-  version = "0.14.0-RC1";
+  version = "0.18.1";
   pname = "dotty-bare";
 
   src = fetchurl {
     url = "https://github.com/lampepfl/dotty/releases/download/${version}/dotty-${version}.tar.gz";
-    sha256 = "0nrgsyhqjlpvnjqgb18pryr8q7knq3dq25jhp98s4wh76nssm1zr";
+    sha256 = "a9e102d8289b6367e737a523691f6ecfe01e1834719f8682f7f1d4cc3c33efed";
   };
 
   propagatedBuildInputs = [ jre ncurses.dev ] ;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
[dotty-0.18.1](https://github.com/lampepfl/dotty/releases/tag/0.18.1)

### Notable Changes

  **Language**
- Implement `@main` functions
- Allow infix operators at start of line
- Drop do while
- Alternative Syntax for Control Expressions
- Allow significant indentation syntax
- Change indentation rules to allow copy-paste
- Switch to the 2.13 standard library
- Allow collective parameters for extension methods
- Implement generic number literals

**Metaprogramming**
- Add `toExprOfTuple` in scala.quoted
- Make `toExprOfTuple` produce tuples with precise types
- Add `quoted.Liftable[TupleN]` with N > 22 to the stdlib
- Add `quoted.Liftable[BigInt]` and `quoted.Liftable[BigDecimal]` to the stdlib
- Add quoted ExprOps toExprOfSeq
- Re-contextualize Liftable.toExpr
- `toExprOfTuple` method with precise types
-Factor out staging from the core of scala.quoted
- Add `scala.quoted.Liftables` to the stdlib
- Remove scala.quoted.QuoteError
- Create dotty-staging library

**Type class derivation**
- Add documentation for type class derivation
- Removed redundant Shape type
- Support implicit scope augmentation for Mirror

**Other**
-  [DOC] Add ScalaDays 2019 talks
- Release sbt-dotty 0.3.4, future-proof isDotty
- In Scala.js mode, compile all lazy vals as thread-unsafe.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).